### PR TITLE
Fix: Agrega datos de País y Provincia (que no tienen ABM) para que se…

### DIFF
--- a/tasks/seed.rb
+++ b/tasks/seed.rb
@@ -10,4 +10,16 @@ namespace :seed do
       end
     end
   end
+  # carga país y provincia que no tienen ABM
+  namespace :basic do
+    task :dev do
+      c = Country.create do |country|
+        country.name = (0...20).map { ('a'..'z').to_a[rand(26)] }.join
+      end
+      p = Province.create do |province|
+        province.name = (0...20).map { ('a'..'z').to_a[rand(26)] }.join
+        province.country = c
+      end
+    end
+  end
 end


### PR DESCRIPTION
Agrego datos de País y Provincia (random) para que se puedan cargar encuestas sin que tire error.

Creo que habría que armar un ABM de países y provincias o un seed con países y provincias (por lo menos los de Argentina) para que quede joya.